### PR TITLE
Task: Add Custom Validation to company email Address (When Present)

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,5 +1,10 @@
 class Company < ApplicationRecord
   has_rich_text :description
 
-
+  validates :email,
+    format: {
+      with: /\A(^[A-Za-z0-9+_.-]+@getmainstreet.com)\z/i,
+      allow_blank: true,
+      message: 'accepts only getmainstreet.com domain'
+    }
 end

--- a/app/views/companies/_form.html.erb
+++ b/app/views/companies/_form.html.erb
@@ -1,5 +1,15 @@
 <div class="py-5">
   <%= form_for @company do |f| %>
+    <% if @company.errors.any? %>
+      <div class="alert alert-danger" role="alert">
+        <strong>Error occurred while submitting form</strong>
+        <ul>
+          <% @company.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
 
     <div class="row my-lg-3">
       <div class="col-lg-3">

--- a/test/controllers/companies_controller_test.rb
+++ b/test/controllers/companies_controller_test.rb
@@ -4,7 +4,7 @@ require "application_system_test_case"
 class CompaniesControllerTest < ApplicationSystemTestCase
 
   def setup
-    @company = companies(:hometown_painting)
+    @company = companies(:own_painting)
   end
 
   test "Index" do
@@ -40,6 +40,18 @@ class CompaniesControllerTest < ApplicationSystemTestCase
     assert_equal "93009", @company.zip_code
   end
 
+  test "Update with invalid data" do
+    visit edit_company_path(@company)
+
+    within("form#edit_company_#{@company.id}") do
+      fill_in("company_name", with: "Updated Test Company")
+      fill_in("company_zip_code", with: "93009")
+      fill_in("company_email", with: "newcompany@example.com")
+      click_button "Update Company"
+    end
+    assert_text "Email accepts only getmainstreet.com domain"
+  end
+
   test "Create" do
     visit new_company_path
 
@@ -47,7 +59,7 @@ class CompaniesControllerTest < ApplicationSystemTestCase
       fill_in("company_name", with: "New Test Company")
       fill_in("company_zip_code", with: "28173")
       fill_in("company_phone", with: "5553335555")
-      fill_in("company_email", with: "new_test_company@test.com")
+      fill_in("company_email", with: "newcompany@getmainstreet.com")
       click_button "Create Company"
     end
 
@@ -58,4 +70,17 @@ class CompaniesControllerTest < ApplicationSystemTestCase
     assert_equal "28173", last_company.zip_code
   end
 
+  test "Create with invalid data" do
+    visit new_company_path
+
+    within("form#new_company") do
+      fill_in("company_name", with: "New Test Company")
+      fill_in("company_zip_code", with: "28173")
+      fill_in("company_phone", with: "5553335555")
+      fill_in("company_email", with: "newcompany@example.com")
+      click_button "Create Company"
+    end
+
+    assert_text "Email accepts only getmainstreet.com domain"
+  end
 end

--- a/test/fixtures/companies.yml
+++ b/test/fixtures/companies.yml
@@ -33,3 +33,9 @@ brown_painting:
   email: "brown_painting@brown_painting.com"
   zip_code:
   phone: "555-808-8888"
+
+own_painting:
+  name: "Own Painting"
+  email: "ownpainting@getmainstreet.com"
+  zip_code:
+  phone: "555-808-8888"

--- a/test/models/company_test.rb
+++ b/test/models/company_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class CompanyTest < ActiveSupport::TestCase
+  test "email should accept blank value" do
+    company = Company.new(email: nil)
+    company.valid?
+
+    assert_empty company.errors[:email]
+  end
+
+  test "email should accept getmainstreet.com domain" do
+    company = Company.new(email: 'newaccount@getmainstreet.com')
+    company.valid?
+
+    assert_empty company.errors[:email]
+  end
+
+  test "email should not accept non getmainstreet.com domain" do
+    company = Company.new(email: 'newaccount@example.com')
+    company.valid?
+
+    assert_includes company.errors[:email],
+      'accepts only getmainstreet.com domain'
+  end
+end


### PR DESCRIPTION
Task Detail:
All email addresses for new companies should only be a @getmainstreet.com domain. A custom error should render when attempting to create or update a company when the email does not match this domain. This should only be when email is present. Blank emails can be ignored.