### PR TITLE
Task: Add City State To Companies from Zip Code.

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,5 +1,21 @@
 class Company < ApplicationRecord
   has_rich_text :description
 
+  before_save :set_resolved_city_and_state,
+    if: -> { zip_code_changed? }
 
+  private
+  def set_resolved_city_and_state
+    # TODO: 2  - move this to background Job
+    zip_resolver = ZipcodeResolver.new(zip_code)
+    zip_resolver.resolve
+
+    unless zip_resolver.city.present?
+      errors.add(:base, 'Unable to resolve zipcode')
+      return false
+    end
+
+    self.city = zip_resolver.city
+    self.state = zip_resolver.state
+  end
 end

--- a/app/services/zipcode_resolver.rb
+++ b/app/services/zipcode_resolver.rb
@@ -1,0 +1,28 @@
+class ZipcodeResolver
+  attr_accessor :zip_code
+  attr_reader   :response
+
+  def initialize(zip_code)
+    @zip_code = zip_code.to_s.strip
+  end
+
+  def city
+    @response.to_h.dig(:city)
+  end
+
+  def state
+    @response.to_h.dig(:state_name)
+  end
+
+  def resolve
+    begin
+      @response = ZipCodes.identify(zip_code)
+    # TODO: 1 Introduce custom exception
+    rescue Exception => e
+      msg = "[ZipcodeResolver]: Error occurred while resolving #{zip_code}."
+      msg += "Details: #{e.message}"
+      Rails.logger.info msg
+      @response = {}
+    end
+  end
+end

--- a/db/migrate/20200709031344_add_city_and_state_to_companies.rb
+++ b/db/migrate/20200709031344_add_city_and_state_to_companies.rb
@@ -1,0 +1,6 @@
+class AddCityAndStateToCompanies < ActiveRecord::Migration[6.0]
+  def change
+    add_column :companies, :city,  :string, limit: 100
+    add_column :companies, :state, :string, limit: 100
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_24_193225) do
+ActiveRecord::Schema.define(version: 2020_07_09_031344) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,8 @@ ActiveRecord::Schema.define(version: 2020_04_24_193225) do
     t.string "zip_code"
     t.string "phone"
     t.string "email"
+    t.string "city", limit: 100
+    t.string "state", limit: 100
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/test/models/company_test.rb
+++ b/test/models/company_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class CompanyTest < ActiveSupport::TestCase
+  def test_city_and_state_on_create
+    company = Company.new(name: 'Mycompany', zip_code: '99501',
+      phone: '555-555-5555', email: 'mycompany@getmainstreet.com')
+    company.save
+
+    company.reload
+    assert_match company.state, "Alaska"
+    assert_match company.city, "Anchorage"
+  end
+
+  def test_city_and_state_on_update
+    company = Company.create(name: 'Mycompany', zip_code: '99501',
+      phone: '555-555-5555', email: 'mycompany@getmainstreet.com')
+    company.save
+    company.reload
+
+    company.update(zip_code: '85001')
+    assert_match company.state, "Arizona"
+    assert_match company.city, "Phoenix"
+  end
+end


### PR DESCRIPTION
Task Detail:
For each company "Show" page there is a placeholder for the City, State for that company. You'll need to leverage the zip code to have that value render the actual City, State. For example: Nashville, TN. It is strongly recommended to use the ZipCodes gem that is already in this project.

Every time the company's zip code is updated this city and state should be updated.

The City and State should be added as attributes to the Company object.